### PR TITLE
Feature/2017 06 05/optional sqlite support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  # Allow for sqlite support in development
+  gem 'sqlite3'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -220,6 +221,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # README
 
 ### Quick Start
+
 * bundle install
 * rake db:migrate
 * rake db:seed
@@ -8,6 +9,7 @@
 * edit candidate information through rails admin by going to /admin (generic login info in secrets.yml for now)
 
 ### Endpoints
+
 * api/candidates (returns all candidates, organized by office)
 * api/candidates/?address=1234 Terminus Rd, Atlanta GA (Returns district for that Atlanta address)
 * api/candidates/?citywide=true (Includes citywide candidates)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-### Quick Start
+## Quick Start
 
 * bundle install
 * rake db:migrate
@@ -8,10 +8,22 @@
 * rails s
 * edit candidate information through rails admin by going to /admin (generic login info in secrets.yml for now)
 
-### Endpoints
+## Endpoints
 
 * api/candidates (returns all candidates, organized by office)
 * api/candidates/?address=1234 Terminus Rd, Atlanta GA (Returns district for that Atlanta address)
 * api/candidates/?citywide=true (Includes citywide candidates)
 * api/districts/:id (returns all candidates for that district)
 * api/candidates/:id (Returns only candidate specified)
+
+## Development Notes
+
+### Database
+
+Disclaimer: Heroku [encourages](https://devcenter.heroku.com/articles/getting-started-with-rails5) using PostgreSQL in development to maintain parity between dev/prod environments.
+
+But, to get things going right out of the box without having a local Postgres server, you can explicitly specify an [SQLite](https://www.sqlite.org/) database by typing the following prior to starting your local server:
+
+```shell
+export DATABASE_URL=sqlite3:db/development.sqlite3
+```


### PR DESCRIPTION
A continuation on https://github.com/jordanstreiff/atlanta-candidate-api/pull/6

While I understand maintaining parity for dev/prod, many would probably like to just hit the ground running to poke around a bit, so why not offer optional SQLite support?