### PR TITLE
Update offices and districts endpoint

### DIFF
--- a/app/controllers/api/candidates_controller.rb
+++ b/app/controllers/api/candidates_controller.rb
@@ -2,26 +2,7 @@ class Api::CandidatesController < Api::ApiController
   helper AddressHelper
 
   def index
-    @offices = Office.all
-    if (params[:citywide] && params[:address])
-      @district_id = AddressHelper.get_district_from_address(params[:address])
-      @offices = Office.where(district_id: @district_id).or(Office.where(district_id: nil))
-    else
-      if (params[:citywide])
-        @offices = Office.where(district_id: nil)
-      end
 
-      if (params[:address])
-        district = AddressHelper.get_district_from_address(params[:address])
-        @offices = []
-        @district_id = district
-        if district
-          @offices = Office.where(district_id: district)
-        end
-      end
-    end
-
-    render :index
   end
 
   def show

--- a/app/controllers/api/districts_controller.rb
+++ b/app/controllers/api/districts_controller.rb
@@ -1,8 +1,7 @@
 class Api::DistrictsController < Api::ApiController
-  helper AddressHelper
 
-  def show
-    @candidates = Office.where(district_id: params[:id]).first.candidates
-    render :show
+  def index
+    @district_id = params[:address] ? Office.find_district_from_address(params[:address]) : nil
+    render :index
   end
 end

--- a/app/controllers/api/offices_controller.rb
+++ b/app/controllers/api/offices_controller.rb
@@ -1,4 +1,10 @@
 class Api::OfficesController < Api::ApiController
+  helper AddressHelper
+
+  def index
+    @offices = Office.find_by_params(params)
+    render :index
+  end
 
   def show
     @office = Office.find(params[:id])

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -20,4 +20,24 @@ class Office < ApplicationRecord
       self.find_by_slug(input)
     end
   end
+  
+  def self.find_by_params(params)
+    offices = Office.all
+    if (params[:citywide] && params[:district_id])
+      offices = Office.where(district_id: params[:district_id]).or(Office.where(district_id: nil))
+    else
+      if (params[:citywide])
+        offices = Office.where(district_id: nil)
+      end
+
+      if (params[:district_id])
+        offices = Office.where(district_id: params[:district_id])
+      end
+    end
+    return offices
+  end
+
+  def self.find_district_from_address(address)
+    AddressHelper.get_district_from_address(address)
+  end
 end

--- a/app/views/api/districts/index.json.jbuilder
+++ b/app/views/api/districts/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.district_id @district_id

--- a/app/views/api/districts/show.json.jbuilder
+++ b/app/views/api/districts/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.candidates @candidates, partial: 'api/candidates/candidate', as: :candidate

--- a/app/views/api/offices/index.json.jbuilder
+++ b/app/views/api/offices/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.district @district_id
+json.offices @offices do |office|
+  json.name office.name
+  json.slug office.name.parameterize
+  json.candidates office.candidates, partial: 'api/candidates/candidate', as: :candidate
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  get 'welcome/index'
-  root 'welcome#index'
 
   namespace :api, defaults: { format: :json } do
     resources :candidates, only: [:index, :show]
-    resources :districts, only: [:show]
+    resources :districts, only: [:index]
     resources :offices, only: [:index, :show]
   end
 end


### PR DESCRIPTION
This addresses #22 #16 #14 and #1 (I know, a little messy, but they were related)

Basically, moved everything that was in districts / candidates over to an offices endpoint. So now:

/api/offices returns all offices, with candidates.
search by address param has been removed for offices
if you include district_id param you will get the office(s) for that district
you can also add citywide param to get back citywide candidates (without or in addition to district office)
you can get district by address using /api/districts?address=123 my st., etc.

So to get back all offices (and candidates) for a particular address you would first
user address query /api/districts?address=:address
and then make offices query with that district id
/api/offices/?district_id=5&citywide=true